### PR TITLE
🐛 ソングを新規フォルダにコピーしたときにNAMファイルが作成されなかった問題を修正

### DIFF
--- a/src/lib/nam.ts
+++ b/src/lib/nam.ts
@@ -184,8 +184,10 @@ export async function writeNamFile(folder: Folder) {
     });
   });
 
-  // バックアップファイルの作成
-  await copyFile(path, path + ".backup");
+  // 既にNAMファイルがあればバックアップファイルの作成
+  if (await exists(path)) {
+    await copyFile(path, path + ".backup");
+  }
 
   const line: string[] = [];
   for await (const song of songs) {


### PR DESCRIPTION
backup 用にファイルをコピーするときに、NAMファイルがないとエラーになっていたため
NAMファイルが既になければ backup ファイルを作らないように修正